### PR TITLE
Revert to multi-script TFJS loading to fix 'tf is not defined' error

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,9 +6,11 @@
   <title>Face Shape Detection</title>
   <link rel="stylesheet" href="FaceDetect.ai/style.css">
 
-  <!-- Load the all-in-one bundle for the model -->
-  <!-- This bundle should include tfjs-core, the model, and backends -->
-  <script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/face-landmarks-detection/dist/face-landmarks-detection.js"></script>
+  <!-- Load specific versions and explicitly include WebGL backend -->
+  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-core@4.10.0/dist/tf-core.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-webgl@4.10.0/dist/tf-backend-webgl.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-converter@4.10.0/dist/tf-converter.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/face-landmarks-detection@1.0.2/dist/face-landmarks-detection.min.js"></script>
 
   <script defer src="FaceDetect.ai/Detect.js"></script>
 </head>


### PR DESCRIPTION
I reverted `index.html` to the multi-script loading strategy, using pinned versions for TensorFlow.js libraries and explicitly including the WebGL backend.

This change is intended to resolve the `ReferenceError: tf is not defined` that was introduced by the single-bundle script. This will likely re-introduce the 'No backend found in registry' error, but that is the next problem to be debugged.