### PR TITLE
I removed the `defer` attribute from the script tag for `Detect.js` i…

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,16 +12,7 @@
   <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-converter@4.10.0/dist/tf-converter.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/face-landmarks-detection@1.0.2/dist/face-landmarks-detection.min.js"></script>
 
-  <!-- Diagnostic script to check for tf object -->
-  <script>
-    if (window.tf) {
-      console.log('DIAGNOSTIC: tf object IS defined. Version: ' + window.tf.version.tfjs);
-    } else {
-      console.error('DIAGNOSTIC: tf object IS NOT defined immediately after script load.');
-    }
-  </script>
-
-  <script defer src="FaceDetect.ai/Detect.js"></script>
+  <script src="FaceDetect.ai/Detect.js"></script>
 </head>
 <body>
   <div class="container">


### PR DESCRIPTION
…n `index.html` to fix a race condition. This enforces a strict, sequential execution order for all scripts, which should resolve the `ReferenceError: tf is not defined` and related initialization race conditions.

I also removed the temporary diagnostic script.