### PR TITLE
I've moved the scripts to the end of the body to fix the DOM loading …

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,14 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Face Shape Detection</title>
   <link rel="stylesheet" href="FaceDetect.ai/style.css">
-
-  <!-- Load specific versions and explicitly include WebGL backend -->
-  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-core@4.10.0/dist/tf-core.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-webgl@4.10.0/dist/tf-backend-webgl.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-converter@4.10.0/dist/tf-converter.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/face-landmarks-detection@1.0.2/dist/face-landmarks-detection.min.js"></script>
-
-  <script src="FaceDetect.ai/Detect.js"></script>
 </head>
 <body>
   <div class="container">
@@ -40,5 +32,12 @@
     <p id="result">Face Shape: Not detected</p>
     <p id="feedback">Feedback: Waiting for input...</p>
   </div>
+
+  <!-- Scripts moved to the end of the body to ensure DOM is loaded first -->
+  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-core@4.10.0/dist/tf-core.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-webgl@4.10.0/dist/tf-backend-webgl.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-converter@4.10.0/dist/tf-converter.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/face-landmarks-detection@1.0.2/dist/face-landmarks-detection.min.js"></script>
+  <script src="FaceDetect.ai/Detect.js"></script>
 </body>
 </html>


### PR DESCRIPTION
…errors.

I moved all the script tags from the `<head>` to the end of the `<body>` in `index.html`. This is the standard practice to ensure that the HTML Document Object Model (DOM) is fully parsed and available before any scripts attempt to access its elements.

This change fixes the `Cannot read properties of null (reading 'getContext')` error and should resolve the cascade of script loading and initialization issues.