### PR TITLE
I added the `@mediapipe/face_mesh` script to `index.html`. This should

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,10 +34,15 @@
   </div>
 
   <!-- Scripts moved to the end of the body to ensure DOM is loaded first -->
-  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-core@4.10.0/dist/tf-core.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-webgl@4.10.0/dist/tf-backend-webgl.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-converter@4.10.0/dist/tf-converter.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/face-landmarks-detection@1.0.2/dist/face-landmarks-detection.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-core@4.10.0/dist/tf-core.min.js" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-webgl@4.10.0/dist/tf-backend-webgl.min.js" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-converter@4.10.0/dist/tf-converter.min.js" crossorigin="anonymous"></script>
+
+  <!-- Add MediaPipe face_mesh script to provide wasm backend and other assets -->
+  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh/face_mesh.js" crossorigin="anonymous"></script>
+
+  <script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/face-landmarks-detection@1.0.2/dist/face-landmarks-detection.min.js" crossorigin="anonymous"></script>
+
   <script src="FaceDetect.ai/Detect.js"></script>
 </body>
 </html>


### PR DESCRIPTION
resolve the 404 'Not Found' error for a required dependency, which in turn should fix the `TypeError: o.FaceMesh is not a constructor` error.

I also added `crossorigin="anonymous"` to all CDN script tags for better security and compatibility.

This should resolve all script loading and initialization issues. The only remaining known bug is the outdated API call in `Detect.js`.